### PR TITLE
Fix MIME type for module script

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -3,6 +3,19 @@ import react from "@vitejs/plugin-react-swc";
 import path from "path";
 import { componentTagger } from "lovable-tagger";
 
+// Middleware to set the correct MIME type for .tsx files
+const setMimeType = () => ({
+  name: 'set-mime-type',
+  configureServer(server) {
+    server.middlewares.use((req, res, next) => {
+      if (req.url.endsWith('.tsx')) {
+        res.setHeader('Content-Type', 'application/javascript');
+      }
+      next();
+    });
+  }
+});
+
 // https://vitejs.dev/config/
 export default defineConfig(({ mode }) => ({
   server: {
@@ -13,6 +26,7 @@ export default defineConfig(({ mode }) => ({
     react(),
     mode === 'development' &&
     componentTagger(),
+    setMimeType()
   ].filter(Boolean),
   resolve: {
     alias: {


### PR DESCRIPTION
main.tsx:1 Failed to load module script: Expected a JavaScript module script but the server responded with a MIME type of "application/octet-stream". Strict MIME type checking is enforced for module scripts per HTML spec.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/imhbm/imhbm.github.io/pull/1?shareId=36b8e9f2-dc14-4d7a-a667-4999c5a93464).